### PR TITLE
Fixed traversal algorithm to retain closest intersection only.

### DIFF
--- a/BVH.cpp
+++ b/BVH.cpp
@@ -44,12 +44,21 @@ bool BVH::getIntersection(const Ray& ray, IntersectionInfo* intersection, bool o
   // Is leaf -> Intersect
   if( node.rightOffset == 0 ) {
    for(uint32_t o=0;o<node.nPrims;++o) {
-				const Object* obj = (*build_prims)[node.start+o];
-				bool hit = obj->getIntersection(ray, intersection);
+				IntersectionInfo current;
 
-				// If we're only looking for occlusion, then any hit is good enough
-				if(occlusion && hit) {
-					return true;
+				const Object* obj = (*build_prims)[node.start+o];
+				bool hit = obj->getIntersection(ray, &current);
+
+				if (hit) {
+					// If we're only looking for occlusion, then any hit is good enough
+					if(occlusion) {
+						return true;
+					}
+
+					// Otherwise, keep the closest intersection only
+					if (current.t < intersection->t) {
+						*intersection = current;
+					}
 				}
    }
 


### PR DESCRIPTION
Fixes #3, the original code did not keep track of the closest intersection and just returned the last intersection which registered a hit, resulting in strange artifacts. This patch uses a local `IntersectionInfo` to compare against: if the current intersection is closer than the best one so far, update the best one so far with the current one (occlusion is still an early return as before).

I only tested the fix on `g++ (Ubuntu 4.8.2-19ubuntu1) 4.8.2` but I suppose it will work everywhere.

Before (changing the radius of the spheres from .005 to .075):

![buggy](https://cloud.githubusercontent.com/assets/1861870/5970344/b8b287e2-a896-11e4-8680-a58b08a562e5.png)

With the fix installed:

![render](https://cloud.githubusercontent.com/assets/1861870/5970345/c1cc197e-a896-11e4-8112-03558269b533.png)
