### PR TITLE
Adding clang-format, updating Makefile, minor changes to BVH traversal

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+﻿---
+BasedOnStyle: Google
+AllowShortFunctionsOnASingleLine: All
+ColumnLimit: 120
+IndentWidth: '2'
+Language: Cpp
+UseTab: Never
+
+...

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ render.ppm
 *.exe
 doxygen/html
 examples/CubeOfSpheres
+examples/ObjFile

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOXYGEN := doxygen
 
 CXXFLAGS := -Wall -Wextra -Werror -Wfatal-errors
-CXXFLAGS := $(CXXFLAGS) -I $(CURDIR)/include
+CXXFLAGS := $(CXXFLAGS) -I $(CURDIR)/include 
 CXXFLAGS := $(CXXFLAGS) -std=c++14
 
 VPATH += include/fast_bvh
@@ -14,9 +14,10 @@ headers := include/FastBVH/BBox.h \
            include/FastBVH/Vector3.h
 
 example_headers := examples/Log.h \
-                   examples/Stopwatch.h
+                   examples/Stopwatch.h \
+                   examples/tiny_obj_loader.h
 
-examples := examples/CubeOfSpheres
+examples := examples/CubeOfSpheres examples/ObjFile
 
 .PHONY: all
 all: simple-target
@@ -25,6 +26,9 @@ all: simple-target
 simple-target: $(examples)
 
 examples/CubeOfSpheres: examples/CubeOfSpheres.cpp $(headers) $(example_headers)
+
+examples/ObjFile: examples/ObjFile.cpp $(headers) $(example_headers)
+	$(CXX) $(CXXFLAGS) -I $(CURDIR)/examples examples/tiny_obj_loader.cc $< -o $@
 
 examples/%: examples/%.cpp
 	$(CXX) $(CXXFLAGS) $< -o $@

--- a/examples/CubeOfSpheres.cpp
+++ b/examples/CubeOfSpheres.cpp
@@ -1,9 +1,9 @@
-#include <cstdio>
-#include <vector>
-#include <cstdlib>
-
 #include <FastBVH/BVH.h>
 #include <FastBVH/Traverser.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
 
 #include "Log.h"
 #include "SimpleScheduler.h"
@@ -16,23 +16,19 @@ using std::vector;
 using namespace FastBVH;
 
 // Return a random number in [0,1]
-float rand01() {
-  return rand() * (1.f / RAND_MAX);
-}
+float rand01() { return rand() * (1.f / RAND_MAX); }
 
 // Return a random vector with each component in the range [-1,1]
-Vector3<float> randVector3() {
-  return Vector3<float> { rand01(), rand01(), rand01() } * 2.0f - Vector3<float> { 1, 1, 1 };
-}
+Vector3<float> randVector3() { return Vector3<float>{rand01(), rand01(), rand01()} * 2.0f - Vector3<float>{1, 1, 1}; }
 
 //! For the purposes of demonstrating the BVH, a simple sphere
 template <typename Float>
 struct Sphere final {
-  Vector3<Float> center; // Center of the sphere
-  Float r, r2; // Radius, Radius^2
+  Vector3<Float> center;  // Center of the sphere
+  Float r, r2;            // Radius, Radius^2
 
   constexpr Sphere(const Vector3<Float>& center, Float radius) noexcept
-    : center(center), r(radius), r2(radius*radius) { }
+      : center(center), r(radius), r2(radius * radius) {}
 };
 
 //! \brief Used for calculating the bounding boxes
@@ -40,18 +36,16 @@ struct Sphere final {
 //! \tparam Float The floating point type of the sphere and bounding box vectors.
 template <typename Float>
 class SphereBoxConverter final {
-public:
+ public:
   //! Converts a sphere to a bounding box.
   //! \param sphere The sphere to convert to a bounding box.
   //! \return A bounding box that encapsulates the sphere.
-  BBox<Float> operator () (const Sphere<Float>& sphere) const noexcept {
-
+  BBox<Float> operator()(const Sphere<Float>& sphere) const noexcept {
     const auto& r = sphere.r;
 
-    auto box_delta = Vector3<Float> { r, r, r };
+    auto box_delta = Vector3<Float>{r, r, r};
 
-    return BBox<Float>(sphere.center - box_delta,
-                       sphere.center + box_delta);
+    return BBox<Float>(sphere.center - box_delta, sphere.center + box_delta);
   }
 };
 
@@ -59,14 +53,13 @@ public:
 //! \tparam Float The floating point type of the spheres and rays.
 template <typename Float>
 class SphereIntersector final {
-public:
+ public:
   //! Indicates if a ray and a sphere intersect.
   //! \param sphere The sphere to check intersection for.
   //! \param ray The ray being traced.
   //! \return An instance of @ref FastBVH::Intersection that contains the intersection
   //! data and indicates whether or not there was actually an intersection.
-  Intersection<Float, Sphere<Float>> operator () (const Sphere<Float>& sphere, const Ray<Float>& ray) const noexcept {
-
+  Intersection<Float, Sphere<Float>> operator()(const Sphere<Float>& sphere, const Ray<Float>& ray) const noexcept {
     const auto& center = sphere.center;
     const auto& r2 = sphere.r2;
 
@@ -75,85 +68,74 @@ public:
     auto ss = dot(s, s);
 
     // Compute discriminant
-    auto disc = sd*sd - ss + r2;
+    auto disc = sd * sd - ss + r2;
 
     // Complex values: No intersection
     if (disc < 0.f) {
       return Intersection<Float, Sphere<Float>>{};
     }
 
+    // There is a positive and negative branch to the intersection equation. Assuming we are always outside of the
+    // sphere, then the first intersection is the negative branch.
     auto t = sd - std::sqrt(disc);
-
     auto hit_pos = ray.o + (ray.d * t);
-
     auto normal = normalize(hit_pos - sphere.center);
 
-    // Assume we are not in a sphere... The first hit is the lesser valued
-    return Intersection<Float, Sphere<Float>> {
-      t, &sphere, normal
-    };
+    return Intersection<Float, Sphere<Float>>{t, &sphere, normal};
   }
 };
 
-} // namespace
+}  // namespace
 
 int main() {
-
   // Create a million spheres packed in the space of a cube
   const unsigned int N = 1000000;
 
   vector<Sphere<float>> objects;
 
   printf("Constructing %d spheres...\n", N);
-  for(size_t i=0; i<N; ++i) {
+  for (size_t i = 0; i < N; ++i) {
     objects.emplace_back(Sphere<float>(randVector3(), .005f));
   }
 
-  BVH<float, Sphere<float>> bvh;
-
   SphereBoxConverter<float> boxConverter;
 
-  Stopwatch sw;
+  Stopwatch stopwatch;
 
   // Compute a BVH for this object set
+  BVH<float, Sphere<float>> bvh;
   bvh.build(std::move(objects), boxConverter);
 
   // Output tree build time and statistics
-  double constructionTime = sw.read();
+  double constructionTime = stopwatch.read();
 
-  LOG_STAT("Built BVH (%u nodes, with %u leafs) in %.02f ms",
-           (unsigned int) bvh.getNodeCount(),
-           (unsigned int) bvh.getLeafCount(),
-           1000.0 * constructionTime);
+  LOG_STAT("Built BVH (%u nodes, with %u leafs) in %.02f ms", (unsigned int)bvh.getNodeCount(),
+           (unsigned int)bvh.getLeafCount(), 1000.0 * constructionTime);
 
   SphereIntersector<float> intersector;
-
   Traverser<float, Sphere<float>, decltype(intersector)> traverser(bvh, intersector);
 
   auto trace_kernel = [traverser](const Ray<float>& ray) {
-    auto isect = traverser.traverse(ray, false);
+    auto isect = traverser.traverse(ray);
     if (isect) {
       // Just for fun, we'll make the color based on the normal
-      return Vector3<float> {
-        std::fabs(isect.normal.x),
-        std::fabs(isect.normal.y),
-        std::fabs(isect.normal.z)
-      };
+      return Vector3<float>{std::fabs(isect.normal.x), std::fabs(isect.normal.y), std::fabs(isect.normal.z)};
     } else {
-      return Vector3<float> { 0, 0, 0 };
+      return Vector3<float>{0, 0, 0};
     }
   };
 
-  constexpr std::size_t width = 800;
-  constexpr std::size_t height = 800;
+  constexpr std::size_t width = 2048;
+  constexpr std::size_t height = 2048;
 
-  printf("Rendering image (%ux%u)...\n",
-         (unsigned int) width,
-         (unsigned int) height);
+  printf("Rendering image (%ux%u)...\n", (unsigned int)width, (unsigned int)height);
 
+  stopwatch.reset();
   SimpleScheduler<float> scheduler(width, height);
-
   scheduler.schedule(trace_kernel);
+  double render_time = stopwatch.read();
 
+  printf("Rendered %lu primary rays in %.2f seconds (%.2f MRays/sec)\n", width * height, render_time,
+         width * height / render_time / 1000000.0);
   scheduler.saveResults("render.ppm");
 }

--- a/examples/Stopwatch.h
+++ b/examples/Stopwatch.h
@@ -9,27 +9,34 @@ namespace FastBVH {
 class Stopwatch final {
   //! A type definition for the clock used by this class.
   using Clock = std::chrono::high_resolution_clock;
+
   //! A type definition for a single point in time.
   using TimePoint = Clock::time_point;
+
   //! A type definition for a duration of time.
   using Duration = std::chrono::duration<double>;
+
   //! The starting time of the stop watch.
   TimePoint start;
+
   //! Gets the current time.
   //! \return The current time.
   static TimePoint now() noexcept {
     return Clock::now();
   }
+  
 public:
   //! Constructs a new instance of the stopwatch.
   Stopwatch() noexcept {
     reset();
   }
+
   //! Resets the stop watch to a new starting time.
   //! This should be called right before the profiling begins.
   void reset() noexcept {
     start = now();
   }
+
   //! Reads the current time value from the stopwatch.
   //! \return The number of ellapsed seconds since either
   //! the construction of the stop watch or the last call

--- a/include/FastBVH/BBox.h
+++ b/include/FastBVH/BBox.h
@@ -23,8 +23,10 @@ struct BBox final {
 
   //! The minimum point of the bounding box.
   Vec3 min;
+
   //! The maximum point of the bounding box.
   Vec3 max;
+
   //! The difference between the max and min
   //! points of the bounding box.
   Vec3 extent;
@@ -86,7 +88,7 @@ struct BBox final {
   //! Calculates the surface area of the box.
   //! \return The surface area of the bounding box.
   constexpr Float surfaceArea() const noexcept {
-    return 2.0f * ((extent.x * extent.z) + (extent.x * extent.y) + (extent.y * extent.z));
+    return Float(2) * ((extent.x * extent.z) + (extent.x * extent.y) + (extent.y * extent.z));
   }
 };
 
@@ -136,17 +138,14 @@ bool BBox<Float>::intersect(const Ray<Float>& ray, Float *tnear, Float *tfar) co
 
 template <typename Float>
 uint32_t BBox<Float>::maxDimension() const noexcept {
-
+  // Assume X axis is longest first
   uint32_t result = 0;
 
-  if (extent.y > extent.x) {
+  if(extent[1] > extent[result])
     result = 1;
-    if (extent.z > extent.y) {
-      result = 2;
-    }
-  } else if (extent.z > extent.x) {
+
+  if(extent[2] > extent[result])
     result = 2;
-  }
 
   return result;
 }

--- a/include/FastBVH/BVH.h
+++ b/include/FastBVH/BVH.h
@@ -20,10 +20,15 @@ template <typename Float>
 struct BVHFlatNode final {
   //! The bounding box of the node.
   BBox<Float> bbox;
+
   //! The index of the first primitive.
   uint32_t start;
+
   //! The number of primitives in this node.
   uint32_t nPrims;
+
+  //! Number of elements to skip in flattened tree to get to a left child's sibling. 
+  //! (Node+1 == Node's left child , Node + rightOffset == Node's right child)
   uint32_t rightOffset;
 };
 
@@ -33,17 +38,22 @@ template <typename Float, typename Primitive>
 class BVH final {
   //! The number of leafs in the BVH.
   uint32_t nLeafs;
+
   //! The number of primitives in a single leaf.
   uint32_t leafSize;
+  
   //! The array of primitives used to construct
   //! the BVH.
   std::vector<Primitive> build_prims;
+
   //! An array of nodes used for fast iteration
   //! of the BVH, using iteration.
   std::vector<BVHFlatNode<Float>> flatTree;
+
 public:
   //! Constructs a new BVH instance.
   BVH() : nLeafs(0), leafSize(4) {}
+
   //! Builds the BVH. This function may be called more than once.
   //! At each call to this function, the nodes in the BVH are cleared
   //! and then remade based on the new data.
@@ -60,26 +70,31 @@ public:
 
     this->build(converter);
   }
+
   //! Gets the number of leafs in the BVH.
   //! \return The number of leafs in the BVH.
   inline auto getLeafCount() const noexcept {
     return nLeafs;
   }
+
   //! Accesses the BVH nodes.
   //! \return A pointer to the nodes in the BVH.
   inline const auto* getNodes() const noexcept {
     return flatTree.data();
   }
+
   //! Gets the number of nodes in the BVH.
   //! \return The node count of the BVH.
   inline auto getNodeCount() const noexcept {
     return flatTree.size();
   }
+
   //! Accesses a pointer to the primitives in the BVH.
   //! \return A const pointer to the primitive array.
   inline const auto* getPrimitives() const noexcept {
     return build_prims.data();
   }
+
 protected:
   //! Build the BVH tree out of build_prims
   //! \param converter The primitive to bounding box converter.
@@ -92,8 +107,10 @@ protected:
 struct BuildEntry final {
   //! If non-zero then this is the index of the parent. (used in offsets)
   uint32_t parent;
+  
   //! The starting index of the range of primitives in this node.
   uint32_t start;
+
   //! The ending index of the range of primitives in this node.
   uint32_t end;
 };

--- a/include/FastBVH/Intersection.h
+++ b/include/FastBVH/Intersection.h
@@ -13,14 +13,19 @@ template <typename Float, typename Primitive>
 struct Intersection final {
   /// A simple type definition for 3D vector.
   using Vec3 = Vector3<Float>;
+
   //! The scale at which the ray reaches the primitive.
   Float t = std::numeric_limits<Float>::infinity();
+
   //! A pointer to the primitive that the ray intersected with.
   const Primitive* object = nullptr;
+
   //! The normal at the point of intersection.
   Vec3 normal = { 0, 0, 1 };
+
   //! The UV coordinates at the position of intersection.
   Float uv[2] = { 0, 0 };
+
   //! Gets the position at the ray hit the object.
   //! \param ray_pos The ray position.
   //! \param ray_dir The ray direction.
@@ -28,6 +33,7 @@ struct Intersection final {
   Vec3 getHitPosition(const Vec3& ray_pos, const Vec3& ray_dir) const noexcept {
     return ray_pos + (ray_dir * t);
   }
+  
   //! Indicates whether or not the intersection is valid.
   //! \return True if the intersection is valid, false otherwise.
   operator bool () const noexcept {

--- a/include/FastBVH/Ray.h
+++ b/include/FastBVH/Ray.h
@@ -15,8 +15,10 @@ struct Ray final {
 
   //! The origin point of the ray.
   Vec3 o;
+  
   //! The direction of the ray.
   Vec3 d;
+
   //! The reciprocal of the ray direction.
   //! Since the reciprocal ray direction is used
   //! quite often, saving the value here saves a

--- a/include/FastBVH/Traverser.h
+++ b/include/FastBVH/Traverser.h
@@ -4,31 +4,39 @@
 
 namespace FastBVH {
 
-//! \brief Used for traversing a BVH
-//! and checking for ray-primitive intersections.
+//! \brief Flags used to configure traverse() method of the BVH.
+enum TraverserFlags {
+  //! If any intersection exists, return immediately. The Intersection data is not populated.
+  OnlyTestOcclusion = 1 << 0,
+};
+
+//! \brief Used for traversing a BVH and checking for ray-primitive intersections.
 //! \tparam Float The floating point type used by vector components.
 //! \tparam Primitive The type of the primitive that the BVH was made with.
 //! \tparam Intersector The type of the primitive intersector.
-template <typename Float, typename Primitive, typename Intersector>
+//! \tparam Flags The flags which configure traversal. See @ref TraverserFlags. By default, no flags are active.
+template <typename Float, typename Primitive, typename Intersector, TraverserFlags Flags = TraverserFlags(0)>
 class Traverser final {
   //! The BVH to be traversed.
   const BVH<Float, Primitive>& bvh;
+
   /// The ray-primitive intersector.
   Intersector intersector;
-public:
+
+ public:
   //! Constructs a new BVH traverser.
   //! \param bvh_ The BVH to be traversed.
   constexpr Traverser(const BVH<Float, Primitive>& bvh_, const Intersector& intersector_) noexcept
-    : bvh(bvh_), intersector(intersector_) {}
+      : bvh(bvh_), intersector(intersector_) {}
+
   //! Traces a single ray throughout the BVH, getting the closest intersection.
   //! \param ray The ray to be traced.
   //! \return An intersection instance.
   //! It may or may not be valid, based on whether or not the ray made a collision.
-  Intersection<Float, Primitive> traverse(const Ray<Float>& ray, bool occlusion) const;
+  Intersection<Float, Primitive> traverse(const Ray<Float>& ray) const;
 };
 
-//! \brief Contains implementation details
-//! for the @ref Traverser class.
+//! \brief Contains implementation details for the @ref Traverser class.
 namespace TraverserImpl {
 
 //! \brief Node for storing state information during traversal.
@@ -36,29 +44,34 @@ template <typename Float>
 struct Traversal final {
   //! The index of the node to be traversed.
   uint32_t i;
+
   //! Minimum hit time for this node.
   Float mint;
+
   //! Constructs an uninitialized instance of a traversal context.
-  constexpr Traversal() noexcept { }
+  constexpr Traversal() noexcept {}
+
   //! Constructs an initialized traversal context.
   //! \param i_ The index of the node to be traversed.
-  constexpr Traversal(int i_, Float mint_) noexcept
-    : i(i_), mint(mint_) { }
+  constexpr Traversal(int i_, Float mint_) noexcept : i(i_), mint(mint_) {}
 };
 
-} // namespace impl
+}  // namespace TraverserImpl
 
-template <typename Float, typename Primitive, typename Intersector>
-Intersection<Float, Primitive> Traverser<Float, Primitive, Intersector>::traverse(const Ray<Float>& ray, bool occlusion) const {
-
+template <typename Float, typename Primitive, typename Intersector, TraverserFlags Flags>
+Intersection<Float, Primitive> Traverser<Float, Primitive, Intersector, Flags>::traverse(
+    const Ray<Float>& ray) const {
   using Traversal = TraverserImpl::Traversal<Float>;
 
+  // Intersection result
   Intersection<Float, Primitive> intersection;
 
+  // Bounding box min-t/max-t for left/right children at some point in the tree
   Float bbhits[4];
   int32_t closer, other;
 
   // Working set
+  // WARNING : The working set size is relatively small here, should be made dynamic or template-configurable
   Traversal todo[64];
   int32_t stackptr = 0;
 
@@ -67,58 +80,53 @@ Intersection<Float, Primitive> Traverser<Float, Primitive, Intersector>::travers
   todo[stackptr].mint = -9999999.f;
 
   const auto* flatTree = bvh.getNodes();
-
   const auto* build_prims = bvh.getPrimitives();
 
-  while(stackptr>=0) {
+  while (stackptr >= 0) {
     // Pop off the next node to work on.
     int ni = todo[stackptr].i;
     Float near = todo[stackptr].mint;
     stackptr--;
-    const auto &node(flatTree[ ni ]);
+    const auto& node(flatTree[ni]);
 
     // If this node is further than the closest found intersection, continue
-    if(near > intersection.t)
-      continue;
+    if (near > intersection.t) continue;
 
     // Is leaf -> Intersect
-    if( node.rightOffset == 0 ) {
-
-      for(uint32_t o=0;o<node.nPrims;++o) {
-
+    if (node.rightOffset == 0) {
+      for (uint32_t o = 0; o < node.nPrims; ++o) {
         const auto& obj = build_prims[node.start + o];
 
         auto current = intersector(obj, ray);
         if (current) {
-          // If we're only looking for occlusion, then any hit is good enough
-          if(occlusion) {
+          // If we're only looking for occlusion, then any hit is good enough to return true
+          if (Flags & TraverserFlags::OnlyTestOcclusion) {
             return current;
           }
           intersection = closest(intersection, current);
         }
       }
 
-    } else { // Not a leaf
+    } else {  // Not a leaf
 
-      bool hitc0 = flatTree[ni+1].bbox.intersect(ray, bbhits, bbhits+1);
-      bool hitc1 = flatTree[ni+node.rightOffset].bbox.intersect(ray, bbhits+2, bbhits+3);
+      bool hitc0 = flatTree[ni + 1].bbox.intersect(ray, bbhits, bbhits + 1);
+      bool hitc1 = flatTree[ni + node.rightOffset].bbox.intersect(ray, bbhits + 2, bbhits + 3);
 
       // Did we hit both nodes?
-      if(hitc0 && hitc1) {
-
+      if (hitc0 && hitc1) {
         // We assume that the left child is a closer hit...
-        closer = ni+1;
-        other = ni+node.rightOffset;
+        closer = ni + 1;
+        other = ni + node.rightOffset;
 
         // ... If the right child was actually closer, swap the relavent values.
-        if(bbhits[2] < bbhits[0]) {
+        if (bbhits[2] < bbhits[0]) {
           std::swap(bbhits[0], bbhits[2]);
           std::swap(bbhits[1], bbhits[3]);
-          std::swap(closer,other);
+          std::swap(closer, other);
         }
 
-        // It's possible that the nearest object is still in the other side, but we'll
-        // check the further-awar node later...
+        // It's possible that the nearest object is still in the other side, but
+        // we'll check the further-awar node later...
 
         // Push the farther first
         todo[++stackptr] = Traversal(other, bbhits[2]);
@@ -128,17 +136,16 @@ Intersection<Float, Primitive> Traverser<Float, Primitive, Intersector>::travers
       }
 
       else if (hitc0) {
-        todo[++stackptr] = Traversal(ni+1, bbhits[0]);
+        todo[++stackptr] = Traversal(ni + 1, bbhits[0]);
       }
 
-      else if(hitc1) {
+      else if (hitc1) {
         todo[++stackptr] = Traversal(ni + node.rightOffset, bbhits[2]);
       }
-
     }
   }
 
   return intersection;
 }
 
-} // namespace FastBVH
+}  // namespace FastBVH

--- a/include/FastBVH/Vector3.h
+++ b/include/FastBVH/Vector3.h
@@ -9,7 +9,7 @@ namespace FastBVH {
 //! as well as the representation of rays and intersections.
 //! \tparam Float The type used for the vector components.
 template <typename Float>
-struct Vector3 final {
+struct alignas(sizeof(float)*4) Vector3 final {
 
   //! The X component of the vector.
   Float x;
@@ -17,17 +17,13 @@ struct Vector3 final {
   Float y;
   //! The Z component of the vector.
   Float z;
-  //! This is an used component, used
-  //! for padding and SSE compatibility.
-  Float w = 1;
 
   //! Adds two vectors.
   Vector3 operator+(const Vector3& b) const noexcept {
     return Vector3 {
       x + b.x,
       y + b.y,
-      z + b.z,
-      w + b.w
+      z + b.z
     };
   }
 
@@ -36,8 +32,7 @@ struct Vector3 final {
     return Vector3 {
       x - b.x,
       y - b.y,
-      z - b.z,
-      w - b.w
+      z - b.z
     };
   }
 
@@ -46,8 +41,7 @@ struct Vector3 final {
     return Vector3 {
       x * b,
       y * b,
-      z * b,
-      w * b
+      z * b
     };
   }
 
@@ -56,8 +50,7 @@ struct Vector3 final {
     return Vector3 {
       x / b,
       y / b,
-      z / b,
-      w / b
+      z / b
     };
   }
 
@@ -67,8 +60,7 @@ struct Vector3 final {
     return Vector3 {
       x * b.x,
       y * b.y,
-      z * b.z,
-      w * b.w
+      z * b.z
     };
   }
 
@@ -77,8 +69,7 @@ struct Vector3 final {
     return Vector3 {
       x / b.x,
       y / b.y,
-      z / b.z,
-      w / b.w
+      z / b.z
     };
   }
 
@@ -87,8 +78,7 @@ struct Vector3 final {
     return Vector3 {
       x / b.x,
       y / b.y,
-      z / b.z,
-      w / b.w
+      z / b.z
     };
   }
 
@@ -132,8 +122,7 @@ inline Vector3<Float> min(const Vector3<Float>& a,
   return Vector3<Float> {
     std::fmin(a.x, b.x),
     std::fmin(a.y, b.y),
-    std::fmin(a.z, b.z),
-    std::fmin(a.w, b.w)
+    std::fmin(a.z, b.z)
   };
 }
 
@@ -146,8 +135,7 @@ inline Vector3<Float> max(const Vector3<Float>& a,
   return Vector3<Float> {
     std::fmax(a.x, b.x),
     std::fmax(a.y, b.y),
-    std::fmax(a.z, b.z),
-    std::fmax(a.w, b.w)
+    std::fmax(a.z, b.z)
   };
 }
 


### PR DESCRIPTION
Attn @tay10r 

* Created .clang-format to standardize a majority of the formatting.
* Added blank lines after the final line of each member data declaration/method. Personal preference, this leads to better readability as you can jump from block to block of text. In ObjFile.cpp, I've tried to make more logical groupings in terms of line breaks, along the same vein.
* Amended Makefile to also build the ObjFile example
* Changed resolution for CubeOfSpheres to 2048^2
* The `occlusion` flag which was a runtime arg is now one of a set of template flags (more in the future potentially). 
* Removed `w` from Vector3 and changed to `alignas` to get the same effect while avoiding the need to actually compute math on w components.

Let me know your thoughts before I merge these.